### PR TITLE
Compatibility fix for php 5.3 http_build_query

### DIFF
--- a/src/V2/Receive/Receive.php
+++ b/src/V2/Receive/Receive.php
@@ -51,7 +51,7 @@ class Receive
         $p = compact('key', 'xpub', 'callback');
         if(!is_null($gap_limit))
             $p['gap_limit'] = $gap_limit;
-        $q = http_build_query($p);
+        $q = http_build_query($p, null, '&');
 
         curl_setopt($this->ch, CURLOPT_POST, false);
         curl_setopt($this->ch, CURLOPT_URL, static::URL.'?'.$q);


### PR DESCRIPTION
Instead & in query php 5.3 generate &amp; text